### PR TITLE
feat: 교차 저장소 정합성(user_id 참조 + 계정삭제 연쇄정리)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,8 @@ zer0-Litter/
 - ✅ **조회 성능(N+1) 제거** — `Complaints.current_status` 비정규화 필드 도입으로 관리자/내 민원 목록·마이페이지를 전수 로딩+항목별 상태조회에서 **DB 레벨 필터 + 페이지 단위 조회**로 전환 (백필 커맨드: `python manage.py backfill_current_status`)
 - ✅ **쓰레기통 근접 검색 최적화** — 전수 스캔 → 위경도 **bounding-box 1차 필터** 후 정확 거리 계산 (실데이터 5,222건 기준 전수 스캔과 동일 결과 검증)
 - ✅ **서비스 계층 분리** — 비대했던 `chatbot_api` 뷰의 영속화/민원 생성 로직을 `chatbot/services.py`로 분리, 단위 테스트 가능화
-- ✅ **CI 파이프라인** — GitHub Actions(`.github/workflows/ci.yml`)로 push·PR 시 35개 테스트 자동 실행
+- ✅ **CI 파이프라인** — GitHub Actions(`.github/workflows/ci.yml`)로 push·PR 시 테스트 자동 실행
+- ✅ **교차 저장소 정합성** — 민원에 `user_id`(SQLite Users.pk) 안정 식별자를 두어 소유권 판정을 username→user_id 로 전환(IDOR·이름변경 견고), 계정 삭제 시 MongoDB 연관 데이터(민원·상태·재민원·채팅·파일) 자동 정리(`post_delete` 신호). 백필: `python manage.py backfill_user_id`
 
 ### 개선 예정
-- **저장소 정합성** — SQLite ↔ MongoDB 간 참조 무결성 보강 또는 저장소 통합 검토
+- **저장소 통합 검토** — 운영 규모 확대 시 Users/민원의 단일 DB(예: PostgreSQL) 통합 또는 user_id 외 ChatHistory 등 잔여 컬렉션까지 참조 일원화

--- a/accounts/apps.py
+++ b/accounts/apps.py
@@ -4,3 +4,7 @@ from django.apps import AppConfig
 class AccountsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'accounts'
+
+    def ready(self):
+        # 계정 삭제 시 MongoDB 연관 데이터 정리 신호 등록
+        from . import signals  # noqa: F401

--- a/accounts/signals.py
+++ b/accounts/signals.py
@@ -1,0 +1,55 @@
+"""교차 저장소 정합성: SQLite의 Users 삭제 시 MongoDB의 연관 데이터를 정리한다.
+
+Users(관계형)와 민원/채팅(MongoDB)은 서로 다른 DB라 FK 연쇄삭제가 동작하지 않는다.
+계정 탈퇴 시 Mongo 쪽 데이터가 고아(orphan)로 남는 문제를 신호로 보완한다.
+"""
+import logging
+
+from django.contrib.auth import get_user_model
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
+
+logger = logging.getLogger(__name__)
+User = get_user_model()
+
+
+def purge_user_mongo_data(user_id, username):
+    """탈퇴 사용자의 MongoDB 연관 데이터(민원·상태·재민원·채팅·파일)를 삭제한다."""
+    from mongoengine.queryset.visitor import Q
+    from common.models_mongo import (
+        Complaints, ComplaintStatus, ReComplaints, ChatHistory, ChatFiles,
+    )
+
+    # 안정 식별자(user_id) 우선, 과거 데이터 호환을 위해 username 도 함께 매칭
+    owner_q = Q(username=username)
+    if user_id is not None:
+        owner_q = owner_q | Q(user_id=user_id)
+
+    complaints = Complaints.objects(owner_q)
+    com_ids = [c.com_id for c in complaints.only('com_id')]
+
+    summary = {}
+    if com_ids:
+        summary['complaint_status'] = ComplaintStatus.objects(com_id__in=com_ids).delete()
+        summary['re_complaints'] = ReComplaints.objects(
+            Q(origin_com_id__in=com_ids) | Q(new_com_id__in=com_ids)
+        ).delete()
+    summary['complaints'] = complaints.delete()
+
+    # 채팅 기록/첨부파일
+    chats = ChatHistory.objects(username=username)
+    chat_pks = [c.id for c in chats.only('id')]
+    if chat_pks:
+        summary['chat_files'] = ChatFiles.objects(chat_id__in=chat_pks).delete()
+    summary['chat_history'] = chats.delete()
+
+    logger.info("탈퇴 사용자(%s) Mongo 데이터 정리: %s", username, summary)
+    return summary
+
+
+@receiver(post_delete, sender=User)
+def on_user_deleted(sender, instance, **kwargs):
+    try:
+        purge_user_mongo_data(getattr(instance, 'id', None), instance.username)
+    except Exception as e:
+        logger.error("탈퇴 사용자 Mongo 정리 실패: %s", e, exc_info=True)

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -76,9 +76,10 @@ def test_login_wrong_password_and_unknown_user_same_message(client):
 def test_mypage_counts_use_current_status(client):
     from common.models_mongo import Complaints
     user = _make_user(username="kim")
-    Complaints(com_id=1, username="kim", com_type="청소요청", current_status="처리중").save()
-    Complaints(com_id=2, username="kim", com_type="수리요청", current_status="처리완료").save()
-    Complaints(com_id=3, username="kim", com_type="기타", current_status="처리완료").save()
+    uid = user.id
+    Complaints(com_id=1, user_id=uid, username="kim", com_type="청소요청", current_status="처리중").save()
+    Complaints(com_id=2, user_id=uid, username="kim", com_type="수리요청", current_status="처리완료").save()
+    Complaints(com_id=3, user_id=uid, username="kim", com_type="기타", current_status="처리완료").save()
     client.force_login(user)
     r = client.get("/accounts/mypage_home/")
     assert r.status_code == 200

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -229,8 +229,8 @@ def login_required_with_modal(view_func):
 @require_GET
 @login_required_with_modal
 def mypage_home(request):
-    username = request.user.username
-    user_complaints = Complaints.objects(username=username)
+    # 소유권은 안정 식별자 user_id 로 판정(username 변경/표시와 무관)
+    user_complaints = Complaints.objects(user_id=request.user.id)
 
     # 카운트는 DB 집계로(항목별 상태조회 제거). current_status='처리완료' 이외는 모두 처리중으로 간주.
     total_count = user_complaints.count()
@@ -264,14 +264,13 @@ def mypage_home(request):
 
 @login_required
 def complaint_all_list(request):
-    username = request.user.username
-
     q = (request.GET.get('q') or '').strip()
     status = (request.GET.get('status') or '').strip()
     d_from = (request.GET.get('from') or '').strip()
     d_to = (request.GET.get('to') or '').strip()
 
-    base_q = Q(username=username)
+    # 소유권은 user_id 기준
+    base_q = Q(user_id=request.user.id)
     if q:
         base_q &= (
             Q(com_contents__icontains=q) |
@@ -355,9 +354,9 @@ def complaint_update_api(request):
     if not com_id:
         return JsonResponse({"ok": False, "msg": "com_id가 없습니다."}, status=400)
 
-    # 본인 소유 문서만
+    # 본인 소유 문서만 (소유권은 user_id 로 판정 → IDOR 방지, username 변경에도 견고)
     try:
-        doc = Complaints.objects.get(com_id=int(com_id), username=request.user.username)
+        doc = Complaints.objects.get(com_id=int(com_id), user_id=request.user.id)
     except (DoesNotExist, ValidationError, ValueError):
         return JsonResponse({"ok": False, "msg": "민원을 찾을 수 없습니다."}, status=404)
 

--- a/chatbot/services.py
+++ b/chatbot/services.py
@@ -186,7 +186,7 @@ def _resolve_com_location(session_id, temp_com_location):
     return ''
 
 
-def create_complaint_from_chat(username, session_id, temp_com_location, result):
+def create_complaint_from_chat(username, session_id, temp_com_location, result, user_id=None):
     """대화가 최종 확정(is_final)되면 민원을 생성하고 임베딩한다.
 
     반환:
@@ -220,6 +220,7 @@ def create_complaint_from_chat(username, session_id, temp_com_location, result):
 
     complaint_data = {
         "com_id": complaint_id,
+        "user_id": user_id,
         "username": username,
         "com_type": com_type_for_db,
         "lat": location_doc.latitude,

--- a/chatbot/tests.py
+++ b/chatbot/tests.py
@@ -85,12 +85,13 @@ def test_create_complaint_success(monkeypatch):
     _save_user_location_msg("s3", 37.5, 127.0)
 
     result = {"is_final": True, "com_type": ["청소요청", "기타"], "summary": "쓰레기 민원 요약"}
-    msg = services.create_complaint_from_chat("u", "s3", "서울특별시 중구", result)
+    msg = services.create_complaint_from_chat("u", "s3", "서울특별시 중구", result, user_id=42)
 
     assert msg is None
     assert Complaints.objects.count() == 1
     c = Complaints.objects.first()
     assert c.com_id >= services.CHATBOT_COM_ID_BASE  # 챗봇 민원 ID 공간
+    assert c.user_id == 42  # 안정 식별자 저장
     assert c.com_type == "청소요청, 기타"
     assert c.com_location == "서울특별시 중구"
     assert c.current_status == "처리중"

--- a/chatbot/views.py
+++ b/chatbot/views.py
@@ -49,7 +49,9 @@ def chatbot_api(request):
     # 첫 요청 시 1회 ChromaDB 초기 로드
     services.ensure_chroma_loaded()
 
-    username = request.user.username if getattr(request.user, "is_authenticated", False) else "guest"
+    is_authed = getattr(request.user, "is_authenticated", False)
+    username = request.user.username if is_authed else "guest"
+    user_id = request.user.id if is_authed else None
     user_input = (request.POST.get('message') or '').strip()
     scenario_id = request.POST.get('scenario_id') or 'default'
     reset_session = (request.POST.get('reset_session') or '').lower() == 'true'
@@ -87,7 +89,8 @@ def chatbot_api(request):
 
     # 최종 확정 시 민원 자동 생성
     try:
-        error_msg = services.create_complaint_from_chat(username, session_id, temp_com_location, result)
+        error_msg = services.create_complaint_from_chat(
+            username, session_id, temp_com_location, result, user_id=user_id)
     except Exception as e:
         logger.error("Complaints 및 임베딩 자동 생성 실패: %s", e, exc_info=True)
         return JsonResponse({

--- a/common/models_mongo.py
+++ b/common/models_mongo.py
@@ -23,6 +23,10 @@ class ComplaintStatus(Document):
 class Complaints(Document):
     com_id = IntField(required=True, unique=True, db_field='com_id')  # 자동 증가 직접 관리 필요
     t_district_id = IntField()
+    # SQLite Users.pk 를 가리키는 안정 식별자(소유권 판정의 기준).
+    # username 은 표시/검색/크롤러용으로 유지하되, 소유권은 user_id 로 본다.
+    # 크롤러/게스트 등 실제 회원이 없는 경우 None.
+    user_id = IntField(null=True)
     username = StringField(max_length=255, required=True)
     re_complain = StringField(max_length=255)
     com_trashcan = StringField(max_length=255)
@@ -39,7 +43,8 @@ class Complaints(Document):
     # 정본 이력은 ComplaintStatus 컬렉션에 그대로 남고, 이 필드는 '최신값' 캐시.
     current_status = StringField(max_length=50, default='처리중')
 
-    meta = {'collection': 'complaints', 'indexes': ['username', 'current_status', '-com_reg_date']}
+    meta = {'collection': 'complaints',
+            'indexes': ['user_id', 'username', 'current_status', '-com_reg_date']}
 
 
 class ReComplaints(Document):

--- a/complain/management/commands/backfill_user_id.py
+++ b/complain/management/commands/backfill_user_id.py
@@ -1,0 +1,36 @@
+"""
+기존 Complaints 문서의 user_id(안정 식별자)를 username 기준으로 백필한다.
+
+user_id 도입 이전 데이터는 username 만 있으므로, 배포 직후 1회 실행해야
+소유권 기반 조회(마이페이지/내 민원/재민원)가 정상 동작한다.
+매칭되는 회원이 없는 데이터(크롤러='crawler', 게스트 등)는 user_id 없이 남는다.
+
+    python manage.py backfill_user_id
+"""
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+
+from common.models_mongo import Complaints
+
+
+class Command(BaseCommand):
+    help = "Complaints.user_id 를 username 기준으로 백필한다."
+
+    def handle(self, *args, **options):
+        User = get_user_model()
+        name_to_id = {u.username: u.id for u in User.objects.all()}
+
+        updated = 0
+        unmatched = 0
+        for c in Complaints.objects(user_id=None).only("com_id", "username", "user_id"):
+            uid = name_to_id.get(c.username)
+            if uid is not None:
+                c.update(set__user_id=uid)
+                updated += 1
+            else:
+                unmatched += 1
+
+        self.stdout.write(self.style.SUCCESS(
+            f"user_id 백필 완료: {updated}건 갱신, "
+            f"{unmatched}건은 매칭 회원 없음(크롤러/게스트 → user_id 없음 유지)"
+        ))

--- a/complain/tests.py
+++ b/complain/tests.py
@@ -13,10 +13,13 @@ def _make_user(username):
     )
 
 
-def _make_complaint(com_id, username, current_status="처리중"):
+def _make_complaint(com_id, owner=None, username="someone", current_status="처리중"):
+    """owner(Users)가 주어지면 user_id/username 을 그 사용자로 설정. 없으면 username 만."""
     return Complaints(
-        com_id=com_id, username=username, com_type="청소요청",
-        com_contents="내용", com_location="서울특별시 중구",
+        com_id=com_id,
+        user_id=(owner.id if owner else None),
+        username=(owner.username if owner else username),
+        com_type="청소요청", com_contents="내용", com_location="서울특별시 중구",
         current_status=current_status,
     ).save()
 
@@ -47,7 +50,8 @@ def test_counter_monotonic():
 @pytest.mark.django_db
 def test_reuse_other_users_complaint_is_404(client):
     attacker = _make_user("attacker")
-    _make_complaint(com_id=1001, username="victim")  # 남의 민원
+    victim = _make_user("victim")
+    _make_complaint(com_id=1001, owner=victim)  # 남의 민원
     client.force_login(attacker)
     r = client.get("/complain/reuse/1001/")
     assert r.status_code == 404
@@ -56,7 +60,7 @@ def test_reuse_other_users_complaint_is_404(client):
 @pytest.mark.django_db
 def test_reuse_own_complaint_is_ok(client):
     owner = _make_user("owner")
-    _make_complaint(com_id=1002, username="owner")
+    _make_complaint(com_id=1002, owner=owner)
     client.force_login(owner)
     r = client.get("/complain/reuse/1002/")
     assert r.status_code == 200
@@ -67,7 +71,8 @@ def test_reuse_own_complaint_is_ok(client):
 @pytest.mark.django_db
 def test_update_other_users_complaint_is_404(client):
     attacker = _make_user("attacker")
-    _make_complaint(com_id=2001, username="victim")
+    victim = _make_user("victim")
+    _make_complaint(com_id=2001, owner=victim)
     client.force_login(attacker)
     r = client.post(
         "/accounts/api/complaints/update/",
@@ -82,7 +87,7 @@ def test_update_other_users_complaint_is_404(client):
 @pytest.mark.django_db
 def test_update_own_complaint_succeeds(client):
     owner = _make_user("owner")
-    _make_complaint(com_id=2002, username="owner")
+    _make_complaint(com_id=2002, owner=owner)
     client.force_login(owner)
     r = client.post(
         "/accounts/api/complaints/update/",
@@ -118,3 +123,27 @@ def test_staff_pending_list_filters_by_current_status(client):
     assert r.status_code == 200
     shown_ids = {it["doc"].com_id for it in r.context["page_obj"].object_list}
     assert shown_ids == {4001}  # 처리중만
+
+
+# ---------- 정합성: 계정 삭제 시 Mongo 연관 데이터 연쇄 정리 ----------
+
+@pytest.mark.django_db
+def test_account_delete_purges_related_mongo_data():
+    from datetime import datetime
+    from common.models_mongo import ComplaintStatus, ChatHistory
+
+    leaver = _make_user("leaver")
+    keeper = _make_user("keeper")
+    _make_complaint(com_id=5001, owner=leaver)
+    ComplaintStatus(status_id=9001, com_id=5001, status_name="처리중", updated_at=datetime.now()).save()
+    ChatHistory(chat_id="chat_x", username="leaver", role="user",
+                content="안녕", created_at=datetime.now()).save()
+    _make_complaint(com_id=5002, owner=keeper)  # 타인 데이터(보존돼야 함)
+
+    leaver.delete()  # post_delete 시그널 → Mongo 정리
+
+    assert Complaints.objects(com_id=5001).count() == 0
+    assert ComplaintStatus.objects(com_id=5001).count() == 0
+    assert ChatHistory.objects(username="leaver").count() == 0
+    # 다른 사용자 데이터는 그대로
+    assert Complaints.objects(com_id=5002).count() == 1

--- a/complain/views.py
+++ b/complain/views.py
@@ -85,7 +85,7 @@ def complain_add(request):
         lon = request.GET.get("lon")
         address = request.GET.get("address")
 
-        qs = Complaints.objects(username=username).order_by('-com_reg_date')[:10]
+        qs = Complaints.objects(user_id=request.user.id).order_by('-com_reg_date')[:10]
         all_complaints = []
         for c in qs:
             # 타입 문자열 통일: 공백 제거 + 빈 값 제거
@@ -138,7 +138,7 @@ def complain_add(request):
     origin_com_id = int(origin_raw) if origin_raw.isdigit() else None
 
     if is_reuse and origin_com_id:
-        owned = Complaints.objects(username=username, com_id=origin_com_id).first()
+        owned = Complaints.objects(user_id=request.user.id, com_id=origin_com_id).first()
         if not owned:
             messages.error(request, '잘못된 재민원 요청입니다.')
             return redirect('accounts:mypage_home')
@@ -166,6 +166,7 @@ def complain_add(request):
         # 1) Complaints 저장
         complaint = Complaints(
             com_id=new_com_id,
+            user_id=request.user.id,
             username=username,
             com_type=com_type,
             com_contents=com_contents,
@@ -215,8 +216,8 @@ def complain_add(request):
 
 @login_required(login_url='accounts:login')
 def complain_reuse(request, com_id):
-    # IDOR 방지: 본인이 작성한 민원만 재사용 가능
-    obj = Complaints.objects(com_id=int(com_id), username=request.user.username).first()
+    # IDOR 방지: 본인이 작성한 민원만 재사용 가능 (소유권은 user_id 기준)
+    obj = Complaints.objects(com_id=int(com_id), user_id=request.user.id).first()
     if not obj:
         raise Http404("해당 민원을 찾을 수 없습니다.")
 
@@ -234,7 +235,7 @@ def complain_reuse(request, com_id):
     }
 
     # 최근 민원 10건(그대로 유지)
-    qs = Complaints.objects(username=request.user.username).order_by('-com_reg_date')[:10]
+    qs = Complaints.objects(user_id=request.user.id).order_by('-com_reg_date')[:10]
     all_complaints = []
     for c in qs:
         type_display = ', '.join(normalize_com_types(c.com_type))
@@ -261,10 +262,9 @@ def complain_reuse(request, com_id):
 @login_required
 @require_GET
 def old_complaints_api(request):
-    username = request.user.username
     limit = int(request.GET.get('limit', 10))
 
-    qs = Complaints.objects(username=username).order_by('-com_reg_date')[:limit]
+    qs = Complaints.objects(user_id=request.user.id).order_by('-com_reg_date')[:limit]
     items = []
     for c in qs:
         type_display = ', '.join(normalize_com_types(c.com_type))


### PR DESCRIPTION
SQLite↔MongoDB 정합성 보강. 민원 소유권을 username→user_id로 전환(IDOR/이름변경 견고), 계정 삭제 시 Mongo 연관 데이터 자동 정리(post_delete 신호). 백필: backfill_user_id. 테스트 36개.