### PR TITLE
ci: CI 환경변수 주입으로 pytest 실패 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,14 @@ jobs:
           pip install -r requirements.in
 
       - name: Run tests
-        # 환경변수(SECRET_KEY 등)는 conftest.py 가 테스트용 기본값을 주입하므로 별도 설정 불필요.
+        # CI 에는 .env 가 없으므로 settings 가 요구하는 환경변수를 테스트용 더미값으로 주입한다.
+        # (pytest-django 가 conftest 보다 먼저 settings 를 로드해 conftest 기본값만으론 부족함)
         # MongoDB 는 mongomock(in-memory), DB 는 SQLite 테스트 DB 를 사용한다.
+        env:
+          SECRET_KEY: test-secret-key
+          DEBUG: "True"
+          ALLOWED_HOSTS: "localhost,127.0.0.1,testserver"
+          MONGO_URI: "mongodb://localhost:27017/complaints_db"
+          OPENAI_API_KEY: test-openai-key
+          KAKAO_MAP_API_KEY: test-kakao-key
         run: pytest


### PR DESCRIPTION
CI에 .env가 없어 SECRET_KEY KeyError로 실패하던 문제 수정. Run tests 스텝에 테스트용 더미 env 주입. 로컬 재현/통과 확인.